### PR TITLE
FIX: prevent second render with if statement

### DIFF
--- a/view/frontend/templates/hyva/customerprice.phtml
+++ b/view/frontend/templates/hyva/customerprice.phtml
@@ -63,6 +63,9 @@ $viewModel = $block->getData('viewModel'); ?>
                                 window.dispatchEvent(new CustomEvent("update-prices-" + productId, detail));
 
                                 if (productInfo.tierPriceHtml) {
+                                    // Make sure to not render this a second time
+                                    if (document.getElementById('customer-tier-price')) return;
+
                                     const tierPriceElement = document.createElement('div');
                                     tierPriceElement.classList.add('py-4', 'my-2', 'tier-price-container');
                                     tierPriceElement.innerHTML = productInfo.tierPriceHtml;


### PR DESCRIPTION
When a product is removed from the minicart, the page is refreshed using JavaScript. This triggers the `updatePrices()` function, which then re-renders the tier prices.

